### PR TITLE
Fix bug in new token logic

### DIFF
--- a/Sources/Wealthsimple/Token.swift
+++ b/Sources/Wealthsimple/Token.swift
@@ -92,7 +92,7 @@ struct Token {
             case .failure:
                 completion(nil)
             case let .success(newToken):
-                token.testIfValid {
+                newToken.testIfValid {
                     if $0 {
                         completion(newToken)
                     } else {


### PR DESCRIPTION
Need to check the new, not old token. Otherwise every token which
was refresh would lead to asking for credentials.