### PR TITLE
Load Transactions with future effective date

### DIFF
--- a/Sources/Wealthsimple/Transaction.swift
+++ b/Sources/Wealthsimple/Transaction.swift
@@ -169,6 +169,7 @@ public struct Transaction {
             url.queryItems?.append(URLQueryItem(name: "effective_date_start", value: dateFormatter.string(from: date)))
             url.queryItems?.append(URLQueryItem(name: "process_date_start", value: dateFormatter.string(from: date)))
         }
+        url.queryItems?.append(URLQueryItem(name: "effective_date_end", value: dateFormatter.string(from: Calendar.current.date(byAdding: .day, value: 7, to: Date())!)))
         var request = URLRequest(url: url.url!)
         let session = URLSession.shared
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
Stock/ETF transactions are recorded before the effective date. This
leads to the positions not balancing before transactions might not be
settled yet.

This change loads transactions which are processed already and will
settle in the next week.